### PR TITLE
Limit NodeJS version to 22.4

### DIFF
--- a/.github/workflows/nodejs-gh-pages.yml
+++ b/.github/workflows/nodejs-gh-pages.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         description: NodeJS version
         type: number
-        default: 22
+        default: 22.4
       pre-build:
         description: Command to run before building
         type: string

--- a/.github/workflows/nodejs-gh-pages.yml
+++ b/.github/workflows/nodejs-gh-pages.yml
@@ -6,7 +6,7 @@ on:
       node-version:
         description: NodeJS version
         type: number
-        default: 22.4
+        default: 22.4 # TODO loosen pin once https://github.com/npm/cli/issues/7657 resolves
       pre-build:
         description: Command to run before building
         type: string


### PR DESCRIPTION
Limit NodeJS version to 22.4 to fix https://github.com/janosh/pymatviz/issues/181 according to https://github.com/npm/cli/issues/7666#issuecomment-2238552112.

Meanwhile not sure if we want to limit this version globally or just for `pymatviz`