### PR TITLE
Reduce default pytest duration shown to 20

### DIFF
--- a/.github/workflows/pytest-release.yml
+++ b/.github/workflows/pytest-release.yml
@@ -22,7 +22,7 @@ on:
       test-cmd:
         description: Run tests
         type: string
-        default: pytest --durations 0 --cov .
+        default: pytest --durations 20 --cov .
       pre-test:
         description: Run before tests
         type: string

--- a/readme.md
+++ b/readme.md
@@ -2,10 +2,10 @@
 
 ## Workflows
 
-- [`.github/workflows/pytest-release.yml`](.github/workflows/pytest-release.yml) - Run all `pytest` functions for a PyPI package and release a new version to PyPI if all tests pass and the run was triggered by a release. Uses `secrets.PYPI_TOKEN` to authenticate with PyPI.
-- [`.github/workflows/nodejs-gh-pages.yml`](.github/workflows/nodejs-gh-pages.yml) - Deploy server-rendered static site to GitHub Pages
-- [`.github/workflows/npm-test-release.yml`](.github/workflows/npm-test-release.yml) - Run all tests for an NPM package (usually written in Playwright and vitest) and release a new version to NPM if all tests pass and the run was triggered by a release. Uses `secrets.NPM_TOKEN` to authenticate with NPM.
-- [`.github/workflows/markdown-link-check.yml`](.github/workflows/markdown-link-check.yml) - Check all links in markdown files are alive.
+- [`pytest-release.yml`](.github/workflows/pytest-release.yml) - Run all `pytest` functions for a PyPI package and release a new version to PyPI if all tests pass and the run was triggered by a release. Uses `secrets.PYPI_TOKEN` to authenticate with PyPI.
+- [`nodejs-gh-pages.yml`](.github/workflows/nodejs-gh-pages.yml) - Deploy server-rendered static site to GitHub Pages
+- [`npm-test-release.yml`](.github/workflows/npm-test-release.yml) - Run all tests for an NPM package (usually written in Playwright and vitest) and release a new version to NPM if all tests pass and the run was triggered by a release. Uses `secrets.NPM_TOKEN` to authenticate with NPM.
+- [`markdown-link-check.yml`](.github/workflows/markdown-link-check.yml) - Check all links in markdown files are alive.
 
 ## Actions
 


### PR DESCRIPTION
- Reduce default pytest duration shown from "all" to 20, to fix #5
> Reporting:
  --durations=N         Show N slowest setup/test durations (N=0 for all)